### PR TITLE
SVF assets urn may contain multibyte characters, so encode before sending request

### DIFF
--- a/src/svf/reader.ts
+++ b/src/svf/reader.ts
@@ -88,10 +88,10 @@ export class Reader {
             throw new Error(`Viewable '${guid}' not found.`);
         }
         const svfUrn = (resources[0] as IDerivativeResourceChild).urn;
-        const svf = await modelDerivativeClient.getDerivative(urn, svfUrn) as Buffer;
+        const svf = await modelDerivativeClient.getDerivative(urn, encodeURI(svfUrn)) as Buffer;
         const baseUri = svfUrn.substr(0, svfUrn.lastIndexOf('/'));
         const resolve = async (uri: string) => {
-            const buffer = await modelDerivativeClient.getDerivative(urn, baseUri + '/' + uri) as Buffer;
+            const buffer = await modelDerivativeClient.getDerivative(urn, encodeURI(baseUri) + '/' + uri) as Buffer;
             return buffer;
         };
         return new Reader(svf, resolve);


### PR DESCRIPTION
The SVF asset URN may contain multi-byte characters. (e.g. Revit project for Japanese edition)
If multi-byte characters are included, the following error will occur when sending a request.

> TypeError [ERR_UNESCAPED_CHARACTERS]: Request path contains unescaped characters

Fixed by encoding URN before sending request to Model Derivative API.

regards.