### PR TITLE
[add] Apply distance-unit property to transform of node.

### DIFF
--- a/src/gltf/writer.ts
+++ b/src/gltf/writer.ts
@@ -209,19 +209,43 @@ export class Writer {
 
         // Setup transformation to glTF coordinate system
         const { metadata } = svf.metadata;
-        if (metadata['world up vector'] && metadata['world front vector']) {
+        if (metadata['world up vector'] && metadata['world front vector'] && metadata['distance unit']) {
             const svfUp = metadata['world up vector'].XYZ;
             const svfFront = metadata['world front vector'].XYZ;
-            if (svfUp && svfFront) {
+            const distanceUnit = metadata['distance unit'].value
+            if (svfUp && svfFront && distanceUnit) {
                 const svfLeft = [
                     svfUp[1] * svfFront[2] - svfUp[2] * svfFront[1],
                     svfUp[2] * svfFront[0] - svfUp[0] * svfFront[2],
                     svfUp[0] * svfFront[1] - svfUp[1] * svfFront[0]
                 ];
+
+                let scale: number
+                switch (distanceUnit) {
+                    case 'centimeter':
+                    case 'cm':
+                        scale = 0.01
+                        break
+                    case 'millimeter':
+                    case 'mm':
+                        scale = 0.001
+                        break
+                    case 'foot':
+                    case 'ft':
+                        scale = 0.3048
+                        break
+                    case 'inch':
+                    case 'in':
+                        scale = 0.0254
+                        break
+                    default:    // "meter" / "m"
+                        scale = 1.0
+                }
+
                 rootNode.matrix = [
-                    svfLeft[0], svfUp[0], svfFront[0], 0,
-                    svfLeft[1], svfUp[1], svfFront[1], 0,
-                    svfLeft[2], svfUp[2], svfFront[2], 0,
+                    svfLeft[0] * scale, svfUp[0] * scale, svfFront[0] * scale, 0,
+                    svfLeft[1] * scale, svfUp[1] * scale, svfFront[1] * scale, 0,
+                    svfLeft[2] * scale, svfUp[2] * scale, svfFront[2] * scale, 0,
                     0, 0, 0, 1
                 ];
             }


### PR DESCRIPTION
The metadata.json included in the SVF contains a property called “distanceUnit”.
As the name suggests, this property indicates the unit of measurement in the context of the model.
Currently, this property is not used when outputting glTF and glb.
I think there are many use cases that display and use full-scale models in AR and VR applications, so it would be useful to make this property available.（I actually use it like that :) .）

If you don't use this property on purpose, I'm happy that you can optionally choose whether to use this property :smile: