### PR TITLE
Fixed a bug related to URI encoding

### DIFF
--- a/src/svf/reader.ts
+++ b/src/svf/reader.ts
@@ -212,7 +212,8 @@ export class Reader {
         const svf = await modelDerivativeClient.getDerivative(urn, encodeURI(svfUrn)) as Buffer;
         const baseUri = svfUrn.substr(0, svfUrn.lastIndexOf('/'));
         const resolve = async (uri: string) => {
-            const buffer = await modelDerivativeClient.getDerivative(urn, encodeURI(baseUri) + '/' + uri) as Buffer;
+            const encodedUri = encodeURI(baseUri  + '/' + uri);
+            const buffer = await modelDerivativeClient.getDerivative(urn, encodedUri) as Buffer;
             return buffer;
         };
         return new Reader(svf, resolve);


### PR DESCRIPTION
This solves a bug which we encountered when having special characters like "ä" or "ß" in the names of texture files.
Before, the second part of the URI was not encoded, therefore Forge responded with an error and the texture was not fetched.